### PR TITLE
Add Rust docs URL and update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![npm](https://img.shields.io/npm/v/flatgeobuf.svg)](https://www.npmjs.com/package/flatgeobuf)
 [![Maven Central](https://img.shields.io/maven-central/v/org.wololo/flatgeobuf.svg)](https://search.maven.org/artifact/org.wololo/flatgeobuf)
 [![Nuget](https://img.shields.io/nuget/v/FlatGeobuf)](https://www.nuget.org/packages/FlatGeobuf/)
+[![Crates.io](https://img.shields.io/crates/v/flatgeobuf.svg)](https://crates.io/crates/flatgeobuf)
 
 A performant binary encoding for geographic data based on [flatbuffers](http://google.github.io/flatbuffers/) that can hold a collection of [Simple Features](https://en.wikipedia.org/wiki/Simple_Features) including circular interpolations as defined by SQL-MM Part 3.
 
@@ -60,7 +61,7 @@ As performance is highly data dependent I've also made similar tests on a larger
 
 ## Features
 
-* Reference implementation for JavaScript, TypeScript, C++ and Java
+* Reference implementation for JavaScript, TypeScript, C++, Java and Rust
 * Efficient I/O (streaming and random access)
 * [GDAL/OGR driver](https://gdal.org/drivers/vector/flatgeobuf.html)
 * [GeoServer WFS output format](https://docs.geoserver.org/latest/en/user/community/flatgeobuf/index.html)
@@ -70,7 +71,6 @@ As performance is highly data dependent I've also made similar tests on a larger
 * Java index support
 * C langauge support
 * Go langauge support
-* Rust language support
 
 ## FAQ
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,10 +5,11 @@ authors = ["Pirmin Kalberer <pka@sourcepole.ch>"]
 edition = "2018"
 description = "FlatGeobuf for Rust."
 homepage = "https://bjornharrtell.github.io/flatgeobuf/"
-repository = "https://github.com/bjornharrtell/flatgeobuf"
+repository = "https://github.com/bjornharrtell/flatgeobuf/tree/master/src/rust"
 readme = "README.md"
-license-file = "../../LICENSE"
-keywords = ["geo", "r-tree"]
+documentation = "https://docs.rs/flatgeobuf/"
+license = "ISC"
+keywords = ["geo", "r-tree", "spatial"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/src/rust/README.md
+++ b/src/rust/README.md
@@ -12,25 +12,21 @@ circular interpolations as defined by SQL-MM Part 3.
 ```rust
 use flatgeobuf::*;
 
-let mut reader = Reader::new(File::open("countries.fgb")?);
-let header = reader.read_header()?;
-let columns_meta = columns_meta(&header);
+let mut file = BufReader::new(File::open("countries.fgb")?);
+let hreader = HeaderReader::read(&mut file)?;
+let header = hreader.header();
 
-reader.select_bbox(8.8, 47.2, 9.5, 55.3)?;
-while let Ok(feature) = reader.next() {
-    let props = read_all_properties(&feature, &columns_meta);
+let mut freader = FeatureReader::select_bbox(&mut file, &header, 8.8, 47.2, 9.5, 55.3)?;
+while let Ok(feature) = freader.next(&mut file) {
+    let props = feature.properties_map(&header);
     println!("{}", props["name"]);
 }
 ```
 
-## Documentation
+See [documentation](https://docs.rs/flatgeobuf/) and [tests](tests/) for more examples.
 
-    cargo doc --open
-
-## Usage
-
-See [tests](tests/)
-
-## Run tests
+## Run tests and benchmarks
 
     cargo test
+
+    cargo bench


### PR DESCRIPTION
Thanks for merging the Rust implemenation! The crate is published on https://crates.io/crates/flatgeobuf and documentation is available on https://docs.rs/flatgeobuf/