### PR TITLE
rust client: log network usage

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,6 +18,7 @@ geozero = "0.5.1"
 async-trait = "0.1"
 reqwest = "0.10"
 bytes = "0.5"
+log = "0.4"
 
 [dev-dependencies]
 geozero-core = "0.5"

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -27,6 +27,7 @@ pub struct HttpFgbReader {
 
 impl HttpFgbReader {
     pub async fn open(url: &str) -> Result<HttpFgbReader> {
+        trace!("starting: opening http reader, reading header");
         let mut client = BufferedHttpClient::new(&url);
         let min_req_size = 512;
         let bytes = client.get(0, 8, min_req_size).await?;
@@ -42,6 +43,7 @@ impl HttpFgbReader {
         let bytes = client.get(12, header_size, min_req_size).await?;
         let header_buf = bytes.to_vec();
 
+        trace!("completed: opening http reader");
         Ok(HttpFgbReader {
             client,
             pos: 0,
@@ -80,6 +82,7 @@ impl HttpFgbReader {
         max_x: f64,
         max_y: f64,
     ) -> Result<usize> {
+        trace!("starting: select_bbox, traversing index");
         // Read R-Tree index and build filter for features within bbox
         let header = self.fbs.header();
         let count = header.features_count() as usize;
@@ -100,6 +103,7 @@ impl HttpFgbReader {
         self.pos = self.feature_base;
         self.count = list.len();
         self.item_filter = Some(list);
+        trace!("completed: select_bbox");
         Ok(self.count)
     }
     /// Number of selected features

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -109,6 +109,9 @@
 //! ```
 //!
 
+#[macro_use]
+extern crate log;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod driver;
 #[allow(dead_code, unused_imports, non_snake_case)]

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -73,9 +73,12 @@ async fn http_err_async() {
     );
     let url = "http://wrong.sourcepole.ch/countries.fgb";
     let fgb = HttpFgbReader::open(url).await;
-    assert_eq!(fgb.err()
-            .unwrap()
-            .to_string(), "http error `error sending request for url (http://wrong.sourcepole.ch/countries.fgb): error trying to connect: dns error: failed to lookup address information: Name or service not known`".to_string());
+    let error_text = fgb.err().unwrap().to_string();
+    let expected_error_text = "error trying to connect";
+    assert!(
+        error_text.contains(expected_error_text),
+        format!("expected to find {} in {}", expected_error_text, error_text)
+    );
 }
 
 #[test]


### PR DESCRIPTION
This captures some rudimentary usage statistics, and, if a logging backend is set-up, can log lines like this:

```
[2020-12-21T19:27:28Z TRACE flatgeobuf::http_reader] starting: opening http reader, reading header
[2020-12-21T19:27:28Z DEBUG flatgeobuf::http_client] request: #1, bytes: (this_request: 512, ever: 512), Range: bytes=0-511
[2020-12-21T19:27:29Z DEBUG flatgeobuf::http_client] request: #2, bytes: (this_request: 520, ever: 1032), Range: bytes=512-1031
[2020-12-21T19:27:29Z TRACE flatgeobuf::http_reader] completed: opening http reader
[2020-12-21T19:27:29Z TRACE flatgeobuf::http_reader] starting: select_bbox, traversing index
[2020-12-21T19:27:29Z DEBUG flatgeobuf::http_client] request: #3, bytes: (this_request: 1048576, ever: 1049608), Range: bytes=1032-1049607
[2020-12-21T19:27:32Z DEBUG flatgeobuf::http_client] request: #4, bytes: (this_request: 1048576, ever: 2098184), Range: bytes=1982072-3030647
[2020-12-21T19:27:34Z DEBUG flatgeobuf::http_client] request: #5, bytes: (this_request: 1048576, ever: 3146760), Range: bytes=31695952-32744527
[2020-12-21T19:27:37Z DEBUG flatgeobuf::http_client] request: #6, bytes: (this_request: 1048576, ever: 4195336), Range: bytes=33971792-35020367
[2020-12-21T19:27:39Z TRACE flatgeobuf::http_reader] completed: select_bbox
[2020-12-21T19:27:39Z DEBUG flatgeobuf::http_client] request: #7, bytes: (this_request: 1048576, ever: 5243912), Range: bytes=268512880-269561455
```

Is this something you'd be interested in including? It might be helpful to evaluate some of the upcoming changes I'd like to propose around what the client fetches.