### PR TITLE
rust http client: optimize index fetching 

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -18,6 +18,7 @@ geozero = "0.5.1"
 async-trait = "0.1"
 reqwest = "0.10"
 bytes = "0.5"
+log = "0.4"
 
 [dev-dependencies]
 geozero-core = "0.5"

--- a/src/rust/src/http_client.rs
+++ b/src/rust/src/http_client.rs
@@ -74,7 +74,7 @@ impl BufferedHttpClient {
 
             // Read additional bytes
             let range_begin = max(begin, self.tail());
-            let range_length = max(length - (range_begin - begin), min_req_size);
+            let range_length = max(begin + length - range_begin, min_req_size);
             let bytes = self.http_client.get(range_begin, range_length).await?;
             self.buf.put(bytes);
         }

--- a/src/rust/src/http_client.rs
+++ b/src/rust/src/http_client.rs
@@ -74,7 +74,6 @@ impl BufferedHttpClient {
 
             // Read additional bytes
             let range_begin = max(begin, self.tail());
-            debug!("http_client#get begin: {}, tail: {}, length: {}, range_begin: {}, min_req_size: {}", begin, self.tail(), length, range_begin, min_req_size);
             let range_length = max(length - (range_begin - begin), min_req_size);
             let bytes = self.http_client.get(range_begin, range_length).await?;
             self.buf.put(bytes);

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -38,14 +38,14 @@ impl HttpFgbReader {
             // The actual branching factor will be in the header, but since we don't have the header
             // yet we guess. The consequence of getting this wrong isn't catastrophic, it just means
             // we may be fetching slightly more than we need or that we make an extra request later.
-            let assumed_branching_factor: usize = 16;
+            let assumed_branching_factor = PackedRTree::DEFAULT_NODE_SIZE as usize;
 
             // NOTE: each layer is exponentially larger
             let prefetched_layers: u32 = 3;
 
-            (0..prefetched_layers).map(|i| {
-                assumed_branching_factor.pow(i) * std::mem::size_of::<NodeItem>()
-            }).sum()
+            (0..prefetched_layers)
+                .map(|i| assumed_branching_factor.pow(i) * std::mem::size_of::<NodeItem>() as usize)
+                .sum()
         };
 
         // In reality, the header is probably less than half this size, but better to overshoot and

--- a/src/rust/src/http_reader.rs
+++ b/src/rust/src/http_reader.rs
@@ -27,6 +27,7 @@ pub struct HttpFgbReader {
 
 impl HttpFgbReader {
     pub async fn open(url: &str) -> Result<HttpFgbReader> {
+        trace!("starting: opening http reader, reading header");
         let mut client = BufferedHttpClient::new(&url);
         let min_req_size = 512;
         let bytes = client.get(0, 8, min_req_size).await?;
@@ -42,6 +43,7 @@ impl HttpFgbReader {
         let bytes = client.get(12, header_size, min_req_size).await?;
         let header_buf = bytes.to_vec();
 
+        trace!("completed: opening http reader");
         Ok(HttpFgbReader {
             client,
             pos: 0,
@@ -80,6 +82,7 @@ impl HttpFgbReader {
         max_x: f64,
         max_y: f64,
     ) -> Result<usize> {
+        trace!("starting: select_bbox, traversing index");
         // Read R-Tree index and build filter for features within bbox
         let header = self.fbs.header();
         let count = header.features_count() as usize;
@@ -100,6 +103,7 @@ impl HttpFgbReader {
         self.pos = self.feature_base;
         self.count = list.len();
         self.item_filter = Some(list);
+        trace!("completed: select_bbox");
         Ok(self.count)
     }
     /// Number of selected features

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -109,6 +109,9 @@
 //! ```
 //!
 
+#[macro_use]
+extern crate log;
+
 #[cfg(not(target_arch = "wasm32"))]
 mod driver;
 #[allow(dead_code, unused_imports, non_snake_case)]

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -538,10 +538,7 @@ impl PackedRTree {
         let item = NodeItem::new(min_x, min_y, max_x, max_y);
         let level_bounds = PackedRTree::generate_level_bounds(num_items, node_size);
         let leaf_nodes_offset = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.0;
-        let num_nodes = level_bounds.first().ok_or(GeozeroError::GeometryIndex)?.1;
         debug!("http_stream_search - index_begin: {}, num_items: {}, node_size: {}, level_bounds: {:?}, GPS bounds:[({}, {}), ({},{})]", index_begin, num_items, node_size, &level_bounds, min_x, min_y, max_x, max_y);
-
-        let min_req_size = cmp::min(num_nodes * size_of::<NodeItem>(), 256 * 1024);
 
         #[derive(Debug, PartialEq, Eq)]
         struct NodeRange {
@@ -571,7 +568,7 @@ impl PackedRTree {
             );
             let length = end - node_index;
             let node_items =
-                read_http_node_items(client, min_req_size, index_begin, node_index, length).await?;
+                read_http_node_items(client, 0, index_begin, node_index, length).await?;
 
             // search through child nodes
             for pos in node_index..end {

--- a/src/rust/src/packed_r_tree.rs
+++ b/src/rust/src/packed_r_tree.rs
@@ -588,7 +588,10 @@ impl PackedRTree {
                 // spend this many extra bytes if it means we'll eliminate an extra request
                 let combine_request_threshold = 256 * 1024 / size_of::<NodeItem>();
 
+                // Add node to search recursion
                 match (queue.back_mut(), node_item.offset as usize) {
+                    // There is an existing node for this level, and it's close to this node.
+                    // Merge the ranges to avoid an extra request
                     (Some(mut head), offset)
                         if head.level == next.level - 1
                             && offset < head.nodes.end + combine_request_threshold =>
@@ -596,25 +599,27 @@ impl PackedRTree {
                         debug_assert!(head.nodes.end < offset);
                         head.nodes.end = offset;
                     }
-                    (Some(head), offset) if head.level == next.level - 1 => {
-                        debug!("creating new NodeRange for offset: {} rather than merging with distant NodeRange: {:?}", offset, head);
-                        debug_assert!(head.nodes.end < offset);
+
+                    (head, offset) => {
                         let node_range = NodeRange {
                             nodes: offset..(offset + 1),
                             level: next.level - 1,
                         };
-                        queue.push_back(node_range);
-                    }
-                    _ => {
-                        let node_range = NodeRange {
-                            nodes: (node_item.offset as usize)..(node_item.offset as usize + 1),
-                            level: next.level - 1,
-                        };
-                        debug!(
-                            "pushing new level for NodeRange: {:?} onto Queue with head: {:?}",
-                            &node_range,
-                            queue.back()
-                        );
+
+                        if head
+                            .as_ref()
+                            .map(|head| head.level == next.level - 1)
+                            .unwrap_or(false)
+                        {
+                            debug!("creating new NodeRange for offset: {} rather than merging with distant NodeRange: {:?}", offset, &head);
+                        } else {
+                            debug!(
+                                "pushing new level for NodeRange: {:?} onto Queue with head: {:?}",
+                                &node_range,
+                                queue.back()
+                            );
+                        }
+
                         queue.push_back(node_range);
                     }
                 }

--- a/src/rust/tests/http_read.rs
+++ b/src/rust/tests/http_read.rs
@@ -73,9 +73,12 @@ async fn http_err_async() {
     );
     let url = "http://wrong.sourcepole.ch/countries.fgb";
     let fgb = HttpFgbReader::open(url).await;
-    assert_eq!(fgb.err()
-            .unwrap()
-            .to_string(), "http error `error sending request for url (http://wrong.sourcepole.ch/countries.fgb): error trying to connect: dns error: failed to lookup address information: Name or service not known`".to_string());
+    let error_text = fgb.err().unwrap().to_string();
+    let expected_error_text = "error trying to connect";
+    assert!(
+        error_text.contains(expected_error_text),
+        format!("expected to find {} in {}", expected_error_text, error_text)
+    );
 }
 
 #[test]


### PR DESCRIPTION
Based on #92, so you'll want to review that one first. Alternatively I can close that one if you'd prefer to just have it all here.

This is based on some of my findings in https://github.com/bjornharrtell/flatgeobuf/issues/90, but excludes any changes which would rely on the not-well-supported `MultiPart Range Requests` for now.

The commits are intended to be separable — each offers independent gains. You might want to review them separately.

The bottom line is:
before: 7 requests totaling 4MB index traversal + 1MB feature fetching
after: 6 requests totaling 512KB index traversal + 1MB feature fetching

This is anecdotal - and depending on where your data lives in the index, you might see more or less requests, but I believe that these changes are rarely worse for small data and often a lot better for large data.

Some context, the file layout is:

`[[Header], [Optional Index], [Features]]`

The header is very small - less than 1kb in my experience.

The optional index, when present, is a tree laid out starting with the root, followed by subsequent layers. Here's the size of each layer assuming branching factor 16:

```
root   = 40*16^0 = 40 bytes
root+1 = 40*16^1 = 640 bytes
root+2 = 40*16^2 = 10KB
root+3 = 40*16^3 = 164KB
root+4 = 40*16^4 = 2.6MB
root+5 = 40*16^5 = 42MB
```

Inlining that into the earlier representation for clarity:
```
[ 
  [Header: <1kb], 
  [[root: 40 bytes], [root+1: 640 bytes], [root+2: 10kb], [164kb], [2.6mb], [42mb], ...], 
  [Features]
]
```

The key insights were: 

1. early layers are very small - try to fetch the first three along with the header

2. The previous approach of fetching extra data to satisfy a minimum request size worked well to eliminate early layers, but now that those early layers are fetched with the header, fetching extra data is unlikely to "randomly" hit useful nodes. Instead we combine nearby requests within a layer, expanding their boundaries up to a reasonable amount, so we can combine the requests.

Notice that there's a "DO NOT MERGE" commit which has some code for logging in tests which I left in for now in case it's helpful to you for the purposes of review.